### PR TITLE
make compilation work when we haven't used namespace std

### DIFF
--- a/include/vg/io/blocked_gzip_output_stream.hpp
+++ b/include/vg/io/blocked_gzip_output_stream.hpp
@@ -2,8 +2,9 @@
 #define VG_BLOCKED_GZIP_OUTPUT_STREAM_HPP_INCLUDED
 
 #include <google/protobuf/io/zero_copy_stream.h>
-
 #include <htslib/bgzf.h>
+#include <iostream>
+#include <vector>
 
 namespace vg {
 

--- a/include/vg/io/registry.hpp
+++ b/include/vg/io/registry.hpp
@@ -19,6 +19,7 @@
 #include <type_traits>
 #include <functional>
 #include <iostream>
+#include <vector>
 #include <google/protobuf/util/type_resolver.h>
 
 namespace vg {
@@ -125,7 +126,7 @@ public:
      * groups (for backward compatibility).
      */
     template<typename Handled, typename... Bases>
-    static void register_loader_saver(const vector<string>& tags, load_function_t loader, save_function_t saver);
+    static void register_loader_saver(const std::vector<std::string>& tags, load_function_t loader, save_function_t saver);
     
     /**
      * Register a loading function and a saving function with the given tag for
@@ -290,7 +291,7 @@ void Registry::register_loader(const string& tag, load_function_t loader) {
     
     // And for the base classes.
     // Expand over all the base types in an initializer list and use an assignment expression to fill a dummy vector.
-    vector<load_function_t> dummy{(tables.tag_to_loader[tag][type_index(typeid(Bases))] = loader)...};
+    std::vector<load_function_t> dummy{(tables.tag_to_loader[tag][type_index(typeid(Bases))] = loader)...};
 }
 
 template<typename Handled>
@@ -320,11 +321,11 @@ void Registry::register_saver(const string& tag, save_function_t saver) {
 template<typename Handled, typename... Bases>
 void Registry::register_loader_saver(const string& tag, load_function_t loader, save_function_t saver) {
     // Dispatch to the vector implementation
-    register_loader_saver<Handled, Bases...>(vector<string>{tag}, loader, saver);
+    register_loader_saver<Handled, Bases...>(std::vector<std::string>{tag}, loader, saver);
 }
 
 template<typename Handled, typename... Bases>
-void Registry::register_loader_saver(const vector<string>& tags, load_function_t loader, save_function_t saver) {
+void Registry::register_loader_saver(const std::vector<std::string>& tags, load_function_t loader, save_function_t saver) {
     // There must be tags
     assert(!tags.empty());
 

--- a/src/blocked_gzip_input_stream.cpp
+++ b/src/blocked_gzip_input_stream.cpp
@@ -3,6 +3,7 @@
 #include "vg/io/hfile_internal.hpp"
 
 #include <htslib/bgzf.h>
+#include <iostream>
 
 namespace vg {
 
@@ -245,8 +246,8 @@ bool BlockedGzipInputStream::Seek(int64_t virtual_offset) {
         // The seek failed
         // Error info is in handle->errcode and handle->fp->has_errno
         // Log the error
-        cerr << "error[vg::BlockedGzipInputStream]: BGZF seek error: errcode: "
-            << handle->errcode << " errno: " << handle->fp->has_errno << endl;
+        std::cerr << "error[vg::BlockedGzipInputStream]: BGZF seek error: errcode: "
+                  << handle->errcode << " errno: " << handle->fp->has_errno << std::endl;
         return false;
     }
     

--- a/src/message_iterator.cpp
+++ b/src/message_iterator.cpp
@@ -61,7 +61,7 @@ auto MessageIterator::operator++() -> const MessageIterator& {
         // Make a CodedInputStream to read the group length
         ::google::protobuf::io::CodedInputStream coded_in(bgzip_in.get());
         // Alot space for group's length, tag's length, and tag (generously)
-        coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2);
+        coded_in.SetTotalBytesLimit(MAX_MESSAGE_SIZE * 2, MAX_MESSAGE_SIZE * 10);
         
         // Try and read the group's length
         if (!coded_in.ReadVarint64((::google::protobuf::uint64*) &group_count)) {


### PR DESCRIPTION
This also changes a call to the protobuf library that seems to need two arguments when it's been installed system wide (libprotobuf-dev/bionic,now 3.0.0-9.1ubuntu1). I'm not sure if this is the right thing to do, or if it becomes incompatible with the version we have in vg.